### PR TITLE
Make callsign positional argument, --callsign not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ requests
 
 ```
 $ ./arrl-call-sign-search.py -h
-usage: arrl-call-sign-search.py [-h] --callsign CALLSIGN
+usage: arrl-call-sign-search.py [-h] callsign
 
 Ham Radio Call Sign Search Utility - ARRL
 
+positional arguments:
+  callsign    ham radio call sign string
+
 options:
-  -h, --help           show this help message and exit
-  --callsign CALLSIGN  ham radio call sign string
+  -h, --help  show this help message and exit
 ```

--- a/arrl-call-sign-search.py
+++ b/arrl-call-sign-search.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
         description="Ham Radio Call Sign Search Utility - ARRL"
     )
     parser.add_argument(
-        "--callsign", type=str, required=True, help="ham radio call sign string"
+        "callsign", type=str, help="ham radio call sign string"
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
It seemed to me that since the callsign is always required I'd just remove the --callsign keyword and make it a positional argument.